### PR TITLE
fix: resolve STT format and segment attribute issues

### DIFF
--- a/backend/src/models/config.py
+++ b/backend/src/models/config.py
@@ -100,7 +100,7 @@ class StorageSettings(BaseSettings):
 class DeepgramSettings(BaseSettings):
     """Deepgram STT configuration."""
 
-    model_config = SettingsConfigDict(env_prefix="DEEPGRAM_")
+    model_config = SettingsConfigDict(env_prefix="DEEPGRAM_", env_file=".env", extra="ignore")
 
     api_key: SecretStr = Field(default=SecretStr(""), description="Deepgram API Key")
     model: str = Field(default="nova-2", description="STT model name")
@@ -111,7 +111,7 @@ class DeepgramSettings(BaseSettings):
 class OpenAISettings(BaseSettings):
     """OpenAI LLM configuration."""
 
-    model_config = SettingsConfigDict(env_prefix="OPENAI_")
+    model_config = SettingsConfigDict(env_prefix="OPENAI_", env_file=".env", extra="ignore")
 
     api_key: SecretStr = Field(default=SecretStr(""), description="OpenAI API Key")
     model: str = Field(default="gpt-4o-mini", description="LLM model name")

--- a/backend/src/services/stt_service.py
+++ b/backend/src/services/stt_service.py
@@ -15,7 +15,7 @@ from src.models.stt import Segment, STTStatus, TranscriptionResponse
 logger = logging.getLogger(__name__)
 
 # Supported audio formats
-SUPPORTED_FORMATS = {".wav", ".mp3", ".flac", ".ogg"}
+SUPPORTED_FORMATS = {".wav", ".mp3", ".flac", ".ogg", ".webm", ".mp4", ".m4a"}
 MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024  # 100MB
 TARGET_SAMPLE_RATE = 16000
 BYTES_PER_SAMPLE = 2  # 16-bit audio
@@ -188,8 +188,8 @@ class STTService:
             segments = [
                 Segment(
                     text=seg.text,
-                    start_time=seg.start_time,
-                    end_time=seg.end_time,
+                    start_time=seg.start_seconds,
+                    end_time=seg.end_seconds,
                 )
                 for seg in result.segments
             ]


### PR DESCRIPTION
## Summary

- Add `.webm`, `.mp4`, `.m4a` to supported audio formats for browser compatibility
- Fix ReazonSpeech Segment attribute names (`start_seconds`/`end_seconds` instead of `start_time`/`end_time`)
- Add `env_file` to `OpenAISettings` and `DeepgramSettings` for proper `.env` loading

## Test plan

- [x] Run `make dev`
- [x] Record voice in browser
- [x] Verify STT transcription works without errors
- [x] Verify LLM response is generated
- [x] Verify TTS audio is played

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)